### PR TITLE
Allow enabling live-reload

### DIFF
--- a/html.js
+++ b/html.js
@@ -1,8 +1,9 @@
 module.exports = formatHTML;
 
-function template(e) {
+function template(e, options) {
 	const load = require("./lazy-load");
 	const styles = load(__dirname + "/html.css");
+	const liveReloadScript = require("./live-reload.js");
 	let hasMessage = e.message && e.message.trim().length;
 
 	return `
@@ -33,6 +34,10 @@ function template(e) {
   ${e.stack ? `
    <div class="stack-trace"><pre>${e.stack}</pre></div>
   ` : ''}
+  ${options.liveReload ? `
+	  <script id="live-reload">${liveReloadScript(options.liveReload)}</script>
+  `: ''}
+
 </main>
   `.trim();
 }
@@ -66,6 +71,16 @@ function addLinks(text) {
 	return out;
 }
 
-function formatHTML(parts){
-	return template(parts);
+function formatHTML(parts, options){
+	let opts = {};
+	if(options) {
+		opts = Object.assign({}, options, {
+			liveReload: options.liveReload === true ?
+				{
+					port: 8012
+				} : options.liveReload
+		})
+	}
+
+	return template(parts, opts);
 }

--- a/live-reload.js
+++ b/live-reload.js
@@ -1,0 +1,22 @@
+
+module.exports = function(data){
+	let {host, port} = data;
+
+	return `
+(function(){
+	if(typeof WebSocket === "undefined") return;
+
+	var host = ${host ? `"${host}"` : "null"} || window.document.location.host.replace(/:.*/, '');
+	var port = ${port ? port : "8012"};
+
+	var protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+	var url = protocol + "//" + host + ":" + port;
+	var ws = new WebSocket(url);
+
+	ws.onmessage = function(){
+		// Just reload and hope it's fixed.
+		window.location.reload();
+	};
+})();
+`;
+};

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,47 @@ app.use(function(error, request, response, next) {
 });
 ```
 
+# API
+
+## .extract(error)
+
+This function takes an [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) and returns an object with parts extracted. This is used to pass into `.html()` and other formatting functions (currently there is only HTML).
+
+## .html(parts)
+
+This function is used to generate formatted HTML. It takes a __parts__ object that comes from using `.extract`.
+
+```js
+let parts = errorFormat.extract(error);
+let html = errorFormat.html(parts);
+```
+
+### .html(parts, options)
+
+The second signature is like the first but takes an __options__ object. The options are:
+
+* __liveReload__: This can either be the boolean `true` or an object that provides the port like: `{ port: 4044 }`. By default the port __8012__ is used (which is the default in DoneJS apps). You only need to set this option if you are using an alternative port in your development server.
+
+Enabling the live-reload script:
+
+```js
+let parts = errorFormat.extract(error);
+let html = errorFormat.html(parts, {
+	liveReload: true
+})
+```
+
+Or with a port:
+
+```js
+let parts = errorFormat.extract(error);
+let html = errorFormat.html(parts, {
+	liveReload: {
+		port: 4044
+	}
+})
+```
+
 # License
 
 MIT

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,7 @@ const {extract, html: formatHTML} = require('../main');
 var fourOhFourError = require('./fixtures/404');
 var stackError = require('./fixtures/stack');
 
-describe.only('HTML options', function(){
+describe('HTML options', function(){
 	describe('liveReload', function(){
 		it('liveReload: null', function(){
 			let parts = extract(fourOhFourError);

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,50 @@ const {extract, html: formatHTML} = require('../main');
 var fourOhFourError = require('./fixtures/404');
 var stackError = require('./fixtures/stack');
 
+describe.only('HTML options', function(){
+	describe('liveReload', function(){
+		it('liveReload: null', function(){
+			let parts = extract(fourOhFourError);
+			let html = formatHTML(parts, {
+				liveReload: null
+			});
+			assert.ok(!/id="live-reload"/.test(html), "includes the script");
+		})
+
+		it('liveReload: true', function(){
+			let parts = extract(fourOhFourError);
+			let html = formatHTML(parts, {
+				liveReload: true
+			});
+
+			assert.ok(/id="live-reload"/.test(html), "includes the script");
+			assert.ok(/var port = 8012/.test(html), "Sets the default port");
+		});
+
+		it('liveReload: {} uses the default port', function(){
+			let parts = extract(fourOhFourError);
+			let html = formatHTML(parts, {
+				liveReload: {}
+			});
+
+			assert.ok(/id="live-reload"/.test(html), "includes the script");
+			assert.ok(/var port = 8012/.test(html), "Sets the default port");
+		});
+
+		it('liveReload: {port} uses the chosen port', function(){
+			let parts = extract(fourOhFourError);
+			let html = formatHTML(parts, {
+				liveReload: {
+					port: 4044
+				}
+			});
+
+			assert.ok(/id="live-reload"/.test(html), "includes the script");
+			assert.ok(/var port = 4044/.test(html), "Sets the default port");
+		});
+	});
+})
+
 describe('Errors with codeFrame', function(){
 	it('Creates good HTML', function(){
 		let parts = extract(fourOhFourError);
@@ -22,4 +66,4 @@ describe('Errors with a stack', function(){
 		assert.ok(!/class="message"/.test(html), "Message not included");
 		assert.ok(/class="stack-trace"/.test(html), "Stack trace is included");
 	});
-})
+});


### PR DESCRIPTION
This adds an options object to the `errorFormat.html()` function. It
currently takes one option `liveReload` which is used for enabling a
live-reload script. done-serve will use this in development.